### PR TITLE
Remove hardcoded sender email and use environment variable for email …

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,5 +1,5 @@
 name: Go-test
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -144,7 +144,6 @@ func (s *Service) sendWelcomeEmail(user *user.User) {
 	ctx := context.Background()
 
 	emailConfig := mailer.Config{
-		From:    "contact@alexandredissi.fr",
 		To:      user.Email,
 		Subject: "Bienvenue sur notre application",
 		Html:    "<p>Bonjour " + user.FirstName + ",</p><p>Merci de vous être inscrit sur notre application.</p>",

--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -3,18 +3,15 @@ package mailer
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/resend/resend-go/v2"
 )
 
 type Config struct {
-	From    string
 	To      string
 	Html    string
 	Subject string
-	Cc      []string
-	Bcc     []string
-	ReplyTo string
 }
 
 // mockgen -source=internal/mailer/mailer.go -destination=internal/mailer/mocks/mock_mailer.go -package=mocks
@@ -33,18 +30,15 @@ func NewMailer(apiKey string) Mailer {
 }
 
 func (m *resendMailer) SendMail(ctx context.Context, config Config) (string, error) {
-	if config.From == "" || len(config.To) == 0 || config.Html == "" || config.Subject == "" {
+	if len(config.To) == 0 || config.Html == "" || config.Subject == "" {
 		return "", fmt.Errorf("from, to, html and subject fields are required")
 	}
 
 	params := &resend.SendEmailRequest{
-		From:    config.From,
+		From:    os.Getenv("SENDER_EMAIL"),
 		To:      []string{config.To},
 		Html:    config.Html,
 		Subject: config.Subject,
-		Cc:      config.Cc,
-		Bcc:     config.Bcc,
-		ReplyTo: config.ReplyTo,
 	}
 
 	sent, err := m.client.Emails.Send(params)

--- a/internal/mailer/mailer_test.go
+++ b/internal/mailer/mailer_test.go
@@ -18,7 +18,6 @@ func TestSendMailSuccess(t *testing.T) {
 
 	ctx := context.Background()
 	emailConfig := mailer.Config{
-		From:    "test@example.com",
 		To:      "recipient@example.com",
 		Subject: "Test Email",
 		Html:    "<p>Hello, this is a test email</p>",
@@ -44,13 +43,9 @@ func TestSendMailWithCompleteConfig(t *testing.T) {
 
 	ctx := context.Background()
 	emailConfig := mailer.Config{
-		From:    "test@example.com",
 		To:      "recipient@example.com",
 		Subject: "Test Email",
 		Html:    "<p>Hello, this is a test email</p>",
-		Cc:      []string{"cc@example.com"},
-		Bcc:     []string{"bcc@example.com"},
-		ReplyTo: "reply@example.com",
 	}
 
 	expectedID := "email_12345"
@@ -73,7 +68,6 @@ func TestSendMailFailure(t *testing.T) {
 
 	ctx := context.Background()
 	emailConfig := mailer.Config{
-		From:    "test@example.com",
 		To:      "recipient@example.com",
 		Subject: "Test Email",
 		Html:    "<p>Hello, this is a test email</p>",


### PR DESCRIPTION
This pull request involves several changes to the email sending functionality in the `internal/mailer` package and the `internal/auth/service.go` file. The main objective is to remove the `From` field from the `mailer.Config` struct and to use an environment variable for the sender email address instead. Additionally, some fields have been removed from the `mailer.Config` struct, and corresponding adjustments have been made in the related tests.

Changes to email sending functionality:

* [`internal/mailer/mailer.go`](diffhunk://#diff-7cde55f7e9466b7f9343177328ac83ff3ec7db161771666aabe81ab655f250e9R6-L17): Removed the `From` field from the `mailer.Config` struct and updated the `SendMail` function to use the `SENDER_EMAIL` environment variable for the sender email address. Also removed the `Cc`, `Bcc`, and `ReplyTo` fields from the `mailer.Config` struct. [[1]](diffhunk://#diff-7cde55f7e9466b7f9343177328ac83ff3ec7db161771666aabe81ab655f250e9R6-L17) [[2]](diffhunk://#diff-7cde55f7e9466b7f9343177328ac83ff3ec7db161771666aabe81ab655f250e9L36-L47)

* [`internal/auth/service.go`](diffhunk://#diff-cff705e23a461e09c022c2359b0aa7cc262cdbedc0af78bec5b06d4d63098e9dL147): Updated the `sendWelcomeEmail` function to remove the `From` field from the `mailer.Config` struct.

Changes to tests:

* [`internal/mailer/mailer_test.go`](diffhunk://#diff-db7b965dcb86841a6248527f04331cb3ad59e957b9027e99cc1c7faac5de6535L21): Updated the `TestSendMailSuccess`, `TestSendMailWithCompleteConfig`, and `TestSendMailFailure` tests to remove the `From` field from the `mailer.Config` struct. [[1]](diffhunk://#diff-db7b965dcb86841a6248527f04331cb3ad59e957b9027e99cc1c7faac5de6535L21) [[2]](diffhunk://#diff-db7b965dcb86841a6248527f04331cb3ad59e957b9027e99cc1c7faac5de6535L47-L53) [[3]](diffhunk://#diff-db7b965dcb86841a6248527f04331cb3ad59e957b9027e99cc1c7faac5de6535L76)