### PR TITLE
Add password reset functionality with token validation

### DIFF
--- a/internal/auth/models.go
+++ b/internal/auth/models.go
@@ -25,6 +25,10 @@ type ForgotPasswordRequest struct {
 	Email string `json:"email" form:"email"`
 }
 
+type ResetPasswordRequest struct {
+	Token    string `json:"token" form:"token"`
+	Password string `json:"password" form:"password"`
+}
 type ErrorResponse struct {
 	Error string `json:"error"`
 }


### PR DESCRIPTION
This pull request introduces new functionality for password reset, including validating reset tokens and resetting passwords. The changes span across multiple files, adding new routes, handlers, models, and repository methods to support this feature.

New password reset functionality:

* [`internal/auth/handler.go`](diffhunk://#diff-eba72bedbb9967a6ffe53035fe6661e207d963a58823c6ba4ea39a089729c791R25-R26): Added new routes for validating reset tokens and resetting passwords. Implemented `ValidateResetToken` and `ResetPassword` handlers. [[1]](diffhunk://#diff-eba72bedbb9967a6ffe53035fe6661e207d963a58823c6ba4ea39a089729c791R25-R26) [[2]](diffhunk://#diff-eba72bedbb9967a6ffe53035fe6661e207d963a58823c6ba4ea39a089729c791R127-R189)
* [`internal/auth/models.go`](diffhunk://#diff-ce49c86fda61a6e883eb562841beb834ca47e4e14aa91185492a7f2a305b784bR28-R31): Introduced `ResetPasswordRequest` struct to handle reset password requests.

Repository updates:

* [`internal/auth/repository.go`](diffhunk://#diff-8d190255996eb8e6ce0cf09c3da6e215b3d2b50d7ef9f771270d0e99b047c801R65-R125): Added methods to validate reset tokens, get user ID by reset token, clear reset tokens, and reset passwords in the database. [[1]](diffhunk://#diff-8d190255996eb8e6ce0cf09c3da6e215b3d2b50d7ef9f771270d0e99b047c801R65-R125) [[2]](diffhunk://#diff-8d190255996eb8e6ce0cf09c3da6e215b3d2b50d7ef9f771270d0e99b047c801L38-R40)

Service layer changes:

* [`internal/auth/service.go`](diffhunk://#diff-cff705e23a461e09c022c2359b0aa7cc262cdbedc0af78bec5b06d4d63098e9dR216-R280): Implemented `ValidateResetToken` and `ResetPassword` methods in the service layer to handle the business logic for password reset.

Minor corrections:

* [`internal/auth/service.go`](diffhunk://#diff-cff705e23a461e09c022c2359b0aa7cc262cdbedc0af78bec5b06d4d63098e9dL152-R152): Fixed a caching bug in the `ForgotPassword` method by correctly setting the cache with the token as the key.