### PR TITLE
Refactor payment integration: replace Stripe service with new Payment…

### DIFF
--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"figenn/internal/mailer"
-	"figenn/internal/stripe"
+	"figenn/internal/payment"
 	"figenn/internal/users"
 	"figenn/internal/utils"
 	"log"
@@ -28,19 +28,19 @@ type Config struct {
 
 type Service struct {
 	repo   *Repository
-	s      *stripe.Service
+	s      *payment.Service
 	config Config
 	cache  gcache.Cache
 	mailer mailer.Mailer
 }
 
-func NewService(repo *Repository, config *Config, mailerClient mailer.Mailer, stripeService *stripe.Service) *Service {
+func NewService(repo *Repository, config *Config, mailerClient mailer.Mailer, paymentService *payment.Service) *Service {
 	return &Service{
 		repo:   repo,
 		config: *config,
 		cache:  gcache.New(100).LRU().Expiration(time.Minute * 5).Build(),
 		mailer: mailerClient,
-		s:      stripeService,
+		s:      paymentService,
 	}
 }
 

--- a/internal/payment/handler.go
+++ b/internal/payment/handler.go
@@ -1,4 +1,4 @@
-package stripe
+package payment
 
 import (
 	"figenn/internal/users"
@@ -20,7 +20,7 @@ func NewAPI(secret string, service *Service) *API {
 }
 
 func (a *API) Bind(rg *echo.Group) {
-	stripeGroup := rg.Group("/stripe")
+	stripeGroup := rg.Group("/payment")
 	stripeGroup.POST("/create-checkout-session", a.HandleCreateCheckoutSession, users.CookieAuthMiddleware(a.JWTSecret))
 	stripeGroup.GET("/subscriptions/:id", a.HandleGetSubscription)
 	stripeGroup.DELETE("/subscriptions/:id", a.HandleCancelSubscription)

--- a/internal/payment/models.go
+++ b/internal/payment/models.go
@@ -1,4 +1,4 @@
-package stripe
+package payment
 
 type CheckoutSessionParams struct {
 	PriceID    string `json:"price_id" form:"price_id"`

--- a/internal/payment/service.go
+++ b/internal/payment/service.go
@@ -1,4 +1,4 @@
-package stripe
+package payment
 
 import (
 	"encoding/json"
@@ -14,7 +14,7 @@ import (
 	"github.com/stripe/stripe-go/v81/customer"
 )
 
-type StripeService interface {
+type PaymentService interface {
 	CreateCheckoutSession(params *CheckoutSessionParams) (*stripe.CheckoutSession, error)
 	GetSubscription(subscriptionID string) (*stripe.Subscription, error)
 	CancelSubscription(subscriptionID string) (*stripe.Subscription, error)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -3,8 +3,9 @@ package server
 import (
 	"figenn/internal/auth"
 	"figenn/internal/mailer"
+	"figenn/internal/payment"
+	stripe "figenn/internal/payment"
 	"figenn/internal/powens"
-	"figenn/internal/stripe"
 	"figenn/internal/subscriptions"
 	"figenn/internal/users"
 	"fmt"
@@ -51,14 +52,14 @@ func (s *Server) setupSubscriptionRoutes(apiGroup *echo.Group) {
 
 func (s *Server) newAuthAPI() *auth.API {
 	authRepo := auth.NewRepository(s.db.Pool())
-	stripeService := stripe.NewService(os.Getenv("STRIPE_SECRET_KEY"), users.NewRepository(s.db))
+	paymentService := payment.NewService(os.Getenv("STRIPE_SECRET_KEY"), users.NewRepository(s.db))
 	authService := auth.NewService(authRepo, &auth.Config{
 		JWTSecret:            s.config.JWTSecret,
 		TokenDuration:        time.Minute * 30,
 		RefreshTokenDuration: time.Hour * 24 * 7 * 4,
 		AppURL:               os.Getenv("APP_URL"),
 		Environment:          os.Getenv("APP_ENV"),
-	}, mailer.NewMailer(), stripeService)
+	}, mailer.NewMailer(), paymentService)
 
 	return auth.NewAPI(authService)
 }


### PR DESCRIPTION
This pull request includes significant changes to rename the `stripe` package to `payment` across the codebase. The most important changes involve updating import paths, renaming files, and modifying type and function names to reflect this change.

Renaming `stripe` to `payment`:

* [`internal/auth/service.go`](diffhunk://#diff-cff705e23a461e09c022c2359b0aa7cc262cdbedc0af78bec5b06d4d63098e9dL9-R9): Updated import path from `figenn/internal/stripe` to `figenn/internal/payment` and modified the `Service` struct and `NewService` function to use `payment.Service` instead of `stripe.Service`. [[1]](diffhunk://#diff-cff705e23a461e09c022c2359b0aa7cc262cdbedc0af78bec5b06d4d63098e9dL9-R9) [[2]](diffhunk://#diff-cff705e23a461e09c022c2359b0aa7cc262cdbedc0af78bec5b06d4d63098e9dL31-R43)
* `internal/stripe/handler.go` renamed to `internal/payment/handler.go`: Changed package name from `stripe` to `payment` and updated route group from `/stripe` to `/payment`. [[1]](diffhunk://#diff-96fa2d03263cc4a32aa3efb66d44caec431b6df47b565b13d8819ef97f56780aL1-R1) [[2]](diffhunk://#diff-96fa2d03263cc4a32aa3efb66d44caec431b6df47b565b13d8819ef97f56780aL23-R23)
* `internal/stripe/models.go` renamed to `internal/payment/models.go`: Changed package name from `stripe` to `payment`.
* `internal/stripe/service.go` renamed to `internal/payment/service.go`: Changed package name from `stripe` to `payment` and updated the interface name from `StripeService` to `PaymentService`. [[1]](diffhunk://#diff-99ea62513f7b04d5c8718a0e50b6d4d66a88e10a096462142a5d59c12162b381L1-R1) [[2]](diffhunk://#diff-99ea62513f7b04d5c8718a0e50b6d4d66a88e10a096462142a5d59c12162b381L17-R17)
* [`internal/server/routes.go`](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R6-L7): Updated import paths and service initialization to use `payment.NewService` instead of `stripe.NewService`. [[1]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640R6-L7) [[2]](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640L54-R62)… service; add payment API handlers and models for checkout sessions and subscriptions